### PR TITLE
Add missing Debian dependency python3-pyside6.qtwebsockets .

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,8 @@ Depends:
  python3-pyside6.qtcore,
  python3-pyside6.qtgui,
  python3-pyside6.qtnetwork,
- python3-pyside6.qtwidgets
+ python3-pyside6.qtwidgets,
+ python3-pyside6.qtwebsockets
 Description: Qt GUI for interacting with Mercury over UDP
  mercury-qt provides a PySide6 desktop client for monitoring and controlling
  Mercury over UDP.


### PR DESCRIPTION
I installed `mercury-qt` from your Debian repository to my Debian Trixie AMD64 box.

Installation went smooth.

Trying to start it: Didn't work. I was greeted with

```
$ mercury-qt
Traceback (most recent call last):
  File "/usr/share/mercury-qt/app.py", line 3, in <module>
    import apps.mercury_qt.app as mercury_qt
  File "/usr/share/mercury-qt/apps/mercury_qt/app.py", line 4, in <module>
    from .modules.main import Main
  File "/usr/share/mercury-qt/apps/mercury_qt/modules/main.py", line 6, in <module>
    from core.connection.websocket.client import WebSocketClient
  File "/usr/share/mercury-qt/core/connection/websocket/client.py", line 38, in <module>
    from PySide6.QtWebSockets import QWebSocket
ModuleNotFoundError: No module named 'PySide6.QtWebSockets'
```

Workaround:

`apt-get install python3-pyside6.qtwebsockets`

That fixed the problem for me.

Investigating further, I think you are missing a dependency in your Debian control file. This PR proposes adding that dependency.

Caveat: I think the change is obvious and correct, but I did not bother to run the final check whether building the Debian package does the trick as intended.

P.S.: Thanks for presenting this exiting development at HAM RADIO Friedrichshafen this year!